### PR TITLE
Update build_and_deploy workflow to 0.12.4

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -147,3 +147,4 @@ jobs:
             }
           ]'
         if: env.WORKFLOW_CONCLUSION == 'failure' || env.WORKFLOW_CONCLUSION == 'timed_out'
+


### PR DESCRIPTION
This PR was automatically triggered due to [a change in the base `build_and_deploy` workflow](https://github.com/CFC-Servers/github_action_workflows/compare/0.12.3..0.12.4)